### PR TITLE
Feature/server

### DIFF
--- a/server/src/api/GetBikeShareStations.ts
+++ b/server/src/api/GetBikeShareStations.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+import { IBikeShareStationResponse } from '../model'
+
+const REQUEST_URL = 'https://bikeshare.metro.net/stations/json/';
+
+interface ServerResponse {
+    data: IBikeShareStationResponse
+}
+
+export default (): Promise<ServerResponse> => {
+    return axios.get(REQUEST_URL, { headers: { 'Accept-Encoding': 'gzip' } })
+}

--- a/server/src/api/GetRegionInformation.ts
+++ b/server/src/api/GetRegionInformation.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+import { IRegionInformationResponse } from '../model'
+
+const REQUEST_URL = 'https://gbfs.bcycle.com/bcycle_lametro/system_regions.json';
+
+interface ServerResponse {
+    data: IRegionInformationResponse
+}
+
+export default (): Promise<ServerResponse> => {
+    return axios.get(REQUEST_URL, { headers: { 'Accept-Encoding': 'gzip' } })
+}

--- a/server/src/api/GetStationStatus.ts
+++ b/server/src/api/GetStationStatus.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+import { IStationStatusResponse } from '../model'
+
+const REQUEST_URL = 'https://gbfs.bcycle.com/bcycle_lametro/station_status.json';
+
+interface ServerResponse {
+    data: IStationStatusResponse
+}
+
+export default (): Promise<ServerResponse> => {
+    return axios.get(REQUEST_URL, { headers: { 'Accept-Encoding': 'gzip' } })
+}

--- a/server/src/api/GetStationsInformation.ts
+++ b/server/src/api/GetStationsInformation.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+import { IStationInformationResponse } from '../model'
+
+const REQUEST_URL = 'https://gbfs.bcycle.com/bcycle_lametro/station_information.json';
+
+interface ServerResponse {
+    data: IStationInformationResponse
+}
+
+export default (): Promise<ServerResponse> => {
+    return axios.get(REQUEST_URL, { headers: { 'Accept-Encoding': 'gzip' } })
+}

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -1,0 +1,4 @@
+export { default as GetBikeShareStations } from './GetBikeShareStations';
+export { default as GetStationsInformation } from './GetStationsInformation';
+export { default as GetStationStatus } from './GetStationStatus';
+export { default as GetRegionInformation } from './GetRegionInformation';

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,0 +1,16 @@
+import express, { Application } from "express";
+import { ApolloServer } from 'apollo-server-express';
+import cors from 'cors';
+
+import { typeDefs, resolvers } from './schema/index';
+
+const server = new ApolloServer({ typeDefs, resolvers })
+
+const app: Application = express();
+
+server.applyMiddleware({ app });
+
+// app.use(cors());
+app.listen(4000, () => {
+  console.log("Now listening for requestion on port 4000");
+});

--- a/server/src/mapper/BikeShareStationResponseMapper.ts
+++ b/server/src/mapper/BikeShareStationResponseMapper.ts
@@ -1,0 +1,35 @@
+import { StationDetail } from '../model/IBikeShareStationResponse'
+
+var objectMapper = require('object-mapper');
+
+var map = {
+  "addressStreet": "address.street",
+  "addressCity": "address.city",
+  "addressState": "address.state",
+  "addressZipCode": "address.zip",
+  "latitude": "latlong.lat",
+  "longitude": "latlong.long",
+  "bikesAvailable": "totalAvailableBikes",
+  "docksAvailable": "emptyDocks",
+  "kioskId": [
+    {
+      key: "id",
+      transform: function (value: number) { return value }
+    },
+    {
+      key: "fullId",
+      transform: function (value: number) { return `bcycle_lametro_${value}` }
+    },
+  ],
+  "name": "name",
+  "classicBikesAvailable": "availableBikesType.classic",
+  "smartBikesAvailable": "availableBikesType.smart",
+  "electricBikesAvailable": "availableBikesType.electric",
+}
+
+const BikeShareStationResponseMapper = (src: StationDetail) => {
+  return objectMapper(src, map);
+}
+
+export default BikeShareStationResponseMapper
+

--- a/server/src/mapper/RegionInformationResponseMapper.ts
+++ b/server/src/mapper/RegionInformationResponseMapper.ts
@@ -1,0 +1,14 @@
+import { RegionInformation } from '../model/IRegionInformationResponse'
+
+var objectMapper = require('object-mapper')
+
+var map = {
+    "region_name": "name",
+    "region_id": "id",
+}
+
+const RegionStatusResponseMapper = (src: RegionInformation) => {
+    return objectMapper(src, map);
+}
+
+export default RegionStatusResponseMapper

--- a/server/src/mapper/StationInformationResponseMapper.ts
+++ b/server/src/mapper/StationInformationResponseMapper.ts
@@ -1,0 +1,19 @@
+import { StationInformation } from '../model/IStationInformationResponse'
+
+var objectMapper = require('object-mapper')
+
+var map = {
+    "lon": "long",
+    "lat": "lat",
+    "region_id": "regionId",
+    "address": "address",
+    "name": "name",
+    "station_id": "id",
+}
+
+const StationInformationResponseMapper = (src: StationInformation) => {
+    return objectMapper(src, map);
+}
+
+export default StationInformationResponseMapper
+

--- a/server/src/mapper/StationStatusResponseMapper.ts
+++ b/server/src/mapper/StationStatusResponseMapper.ts
@@ -1,0 +1,18 @@
+import { Status } from '../model/IStationStatusResponse'
+
+var objectMapper = require('object-mapper')
+
+var map = {
+    "id": "station_id",
+    "num_docks_available": "emptyDocks",
+    "num_bikes_available": "totalBikesAvailable",
+    "num_bikes_available_types.electric": "bikesAvailabilityType.electric",
+    "num_bikes_available_types.smart": "bikesAvailabilityType.smart",
+    "num_bikes_available_types.classic": "bikesAvailabilityType.classic",
+}
+
+const StationStatusResponseMapper = (src: Status) => {
+    return objectMapper(src, map);
+}
+
+export default StationStatusResponseMapper

--- a/server/src/mapper/index.ts
+++ b/server/src/mapper/index.ts
@@ -1,0 +1,4 @@
+export { default as BikeShareStationResponseMapper } from './BikeShareStationResponseMapper';
+export { default as RegionInformationResponseMapper } from './RegionInformationResponseMapper';
+export { default as StationInformationResponseMapper } from './StationInformationResponseMapper';
+export { default as StationStatusResponseMapper } from './StationStatusResponseMapper';

--- a/server/src/model/IBIkeShareStation.ts
+++ b/server/src/model/IBIkeShareStation.ts
@@ -1,0 +1,30 @@
+interface IBikeShareStation {
+    id: string;
+    fullId: string
+    name: string;
+    address: IAddress;
+    latlong: ILatLong;
+    totalAvailableBikes: number,
+    availableBikesType: IAvailableBikesType;
+    emptyDocks: number;
+}
+
+interface IAvailableBikesType {
+    classic: number;
+    electric: number;
+    smart: number;
+}
+
+interface IAddress {
+    street: string;
+    city: string;
+    state: string;
+    zip: string;
+}
+
+interface ILatLong {
+    lat: number;
+    long: number;
+}
+
+export default IBikeShareStation;

--- a/server/src/model/IBikeShareStationResponse.ts
+++ b/server/src/model/IBikeShareStationResponse.ts
@@ -1,0 +1,25 @@
+interface IBikeShareStationResponse {
+    features: Properties[]
+}
+
+interface Properties {
+    properties: StationDetail
+}
+
+export interface StationDetail {
+    addressStreet: String;
+    addressCity: String;
+    addressState: String
+    addressZipCode: String;
+    latitude: Number;
+    longtitude: Number;
+    bikesAvailable: Number;
+    docksAvailable: Number;
+    kioskId: Number;
+    name: String;
+    classicBikesAvailable: Number;
+    smartBikesAvailable: Number;
+    electricBikesAvailable: Number;
+}
+
+export default IBikeShareStationResponse

--- a/server/src/model/IRegionInformation.ts
+++ b/server/src/model/IRegionInformation.ts
@@ -1,0 +1,6 @@
+interface IRegionInformation {
+    name: String;
+    id: String;
+}
+
+export default IRegionInformation;

--- a/server/src/model/IRegionInformationResponse.ts
+++ b/server/src/model/IRegionInformationResponse.ts
@@ -1,0 +1,15 @@
+interface IRegionInformationResponse {
+    data: Regions;
+    last_updated: Number;
+}
+
+interface Regions {
+    regions: RegionInformation[]
+}
+
+export interface RegionInformation {
+    region_name: String;
+    region_id: String;
+}
+
+export default IRegionInformationResponse

--- a/server/src/model/IStationInformation.ts
+++ b/server/src/model/IStationInformation.ts
@@ -1,0 +1,10 @@
+interface IStationInformation {
+    lat: number
+    long: number
+    regionId: string
+    address: string
+    name: string
+    id: string
+}
+
+export default IStationInformation;

--- a/server/src/model/IStationInformationResponse.ts
+++ b/server/src/model/IStationInformationResponse.ts
@@ -1,0 +1,19 @@
+interface IStationInformationResponse {
+    data: Stations
+    last_updated: Number;
+}
+
+interface Stations {
+    stations: StationInformation[]
+}
+
+export interface StationInformation {
+    lon: Number;
+    lat: Number;
+    region_id: String;
+    address: String;
+    name: String;
+    station_id: String;
+}
+
+export default IStationInformationResponse

--- a/server/src/model/IStationStatus.ts
+++ b/server/src/model/IStationStatus.ts
@@ -1,0 +1,14 @@
+interface IStationStatus {
+    id: String;
+    emptyDocks: Number;
+    totalBikesAvailable: Number;
+    bikesAvailabilityType: BikesAvailabilityTypes
+}
+
+interface BikesAvailabilityTypes {
+    electric: Number;
+    smart: Number;
+    classic: Number;
+}
+
+export default IStationStatus

--- a/server/src/model/IStationStatusResponse.ts
+++ b/server/src/model/IStationStatusResponse.ts
@@ -1,0 +1,22 @@
+interface IStationStatusResponse {
+    data: Stations
+    last_updated: Number;
+}
+
+interface Stations {
+    stations: Status[]
+}
+
+interface BikesAvailabilityTypes {
+    electric: Number;
+    smart: Number;
+    classic: Number;
+}
+
+export interface Status {
+    station_id: String;
+    num_bikes_available: Number;
+    num_bikes_available_types: BikesAvailabilityTypes;
+}
+
+export default IStationStatusResponse

--- a/server/src/model/index.ts
+++ b/server/src/model/index.ts
@@ -1,0 +1,7 @@
+export { default as IBikeShareStation } from './IBIkeShareStation';
+export { default as IBikeShareStationResponse } from './IBikeShareStationResponse';
+export { default as IStationInformationResponse } from './IStationInformationResponse';
+export { default as IStationInformation } from './IStationInformation';
+export { default as IStationStatusResponse } from './IStationStatusResponse';
+export { default as IRegionInformationResponse } from './IRegionInformationResponse';
+export { default as IRegionInformation } from './IRegionInformation';

--- a/server/src/schema/index.ts
+++ b/server/src/schema/index.ts
@@ -1,11 +1,18 @@
 import _ from 'lodash';
 import { gql } from 'apollo-server-express';
 import { IBikeShareStation, IStationInformation, IRegionInformation } from '../model';
-import { GetBikeShareStations, GetStationsInformation, GetStationStatus, GetRegionInformation } from '../api'
-import BikeShareStationResponseMapper from '../mapper/BikeShareStationResponseMapper';
-import StationInformationResponseMapper from '../mapper/StationInformationResponseMapper';
-import StationStatusResponseMapper from '../mapper/StationStatusResponseMapper';
-import RegionInformationResponseMapper from '../mapper/RegionInformationResponseMapper';
+import {
+  GetBikeShareStations,
+  GetStationsInformation,
+  GetStationStatus,
+  GetRegionInformation
+} from '../api'
+import {
+  BikeShareStationResponseMapper,
+  StationInformationResponseMapper,
+  StationStatusResponseMapper,
+  RegionInformationResponseMapper
+} from '../mapper'
 
 export const typeDefs = gql`
   type Query {

--- a/server/src/schema/index.ts
+++ b/server/src/schema/index.ts
@@ -1,0 +1,180 @@
+import _ from 'lodash';
+import { gql } from 'apollo-server-express';
+import { IBikeShareStation, IStationInformation, IRegionInformation } from '../model';
+import { GetBikeShareStations, GetStationsInformation, GetStationStatus, GetRegionInformation } from '../api'
+import BikeShareStationResponseMapper from '../mapper/BikeShareStationResponseMapper';
+import StationInformationResponseMapper from '../mapper/StationInformationResponseMapper';
+import StationStatusResponseMapper from '../mapper/StationStatusResponseMapper';
+import RegionInformationResponseMapper from '../mapper/RegionInformationResponseMapper';
+
+export const typeDefs = gql`
+  type Query {
+    bikeShareStationFull(id: Int): BikeShareStationFull,
+    bikeShareStationsFull: [BikeShareStationFull],
+    bikeShareStations:[StationInformation],
+    regions:[RegionInformation],
+  }
+
+  ## Start: Full Query Schema ##
+  ## no longer used
+  type BikeShareStationFull {
+    id: ID
+    fullId: ID
+    name: String
+    address: Address
+    latlong: LatLong
+    totalAvailableBikes: Int
+    bikesAvailabilityType: BikesAvailabilityType
+    emptyDocks: Int
+  }
+
+  type Address {
+    street: String
+    city: String
+    state: String
+    zip: String
+  }
+
+  type LatLong {
+    lat: Float
+    long: Float
+  }
+
+  ## End: Full Query Schema ##
+
+  type StationInformation {
+    lat: Float
+    long: Float
+    regionId: String
+    regionInfo: RegionInformation
+    address: String
+    name: String
+    id: String
+    status: StationStatus
+  }
+
+  type StationStatus {
+    id: String
+    emptyDocks: Int
+    totalBikesAvailable: Int
+    bikesAvailabilityType: BikesAvailabilityType
+  }
+
+  type BikesAvailabilityType {
+    classic: Int
+    electric: Int
+    smart: Int
+  }
+
+  type RegionInformation {
+    id: String
+    name: String
+    stations: [StationInformation]
+  }
+`;
+
+export const resolvers = {
+  Query: {
+    bikeShareStationFull: async (parent: any, args: { id: number; }) => {
+      return await GetBikeShareStations()
+        .then((response) => {
+          const { data } = response;
+          const { features } = data;
+          const selectedStation = _.find(features, (item) => (item.properties.kioskId === args.id));
+          if (selectedStation) {
+            return BikeShareStationResponseMapper(selectedStation.properties);
+          }
+          throw "Selected station is not avaiable or invalid id has been input";
+        })
+    },
+    bikeShareStationsFull: async () => {
+      let stations: IBikeShareStation[] = [];
+      return await GetBikeShareStations()
+        .then((response) => {
+          const { data } = response;
+          const { features } = data;
+          features.forEach((feature) => {
+            const { properties } = feature;
+            stations.push(BikeShareStationResponseMapper(properties));
+          });
+
+          if (stations.length > 0) return stations;
+
+          throw "An error has occured"
+        })
+    },
+    bikeShareStations: async () => {
+      let stationsList: IStationInformation[] = [];
+      return await GetStationsInformation()
+        .then((response) => {
+          const { data } = response.data
+          const { stations } = data
+          stations.forEach((station) => {
+            stationsList.push(StationInformationResponseMapper(station));
+          });
+
+          if (stationsList.length > 0) return stationsList;
+
+          throw "An error has occured"
+        })
+    },
+    regions: async () => {
+      let regionsList: IRegionInformation[] = [];
+      return await GetRegionInformation()
+        .then((response) => {
+          const { data } = response.data
+          const { regions } = data
+          regions.forEach((region) => {
+            regionsList.push(RegionInformationResponseMapper(region));
+          });
+
+          if (regions.length > 0) return regionsList;
+
+          throw "An error has occured fetching all regions"
+        })
+
+    }
+  },
+  StationInformation: {
+    status: async (stationInformation: IStationInformation) => {
+      return await GetStationStatus()
+        .then((response) => {
+          const { data } = response.data
+          const { stations } = data
+          const selectedStationStatus = _.find(stations, (item) => (item.station_id === stationInformation.id));
+          if (selectedStationStatus) {
+            return StationStatusResponseMapper(selectedStationStatus);
+          }
+          throw "Selected station status is not avaiable"
+        })
+    },
+    regionInfo: async (stationInformation: IStationInformation) => {
+      return await GetRegionInformation()
+        .then((response) => {
+          const { data } = response.data
+          const { regions } = data
+          const selectedRegion = _.find(regions, (item) => (item.region_id === stationInformation.regionId));
+          if (selectedRegion) {
+            return RegionInformationResponseMapper(selectedRegion);
+          }
+          throw "Selected region is not avaiable"
+        })
+    },
+  },
+  RegionInformation: {
+    stations: async (regionInformation: IRegionInformation) => {
+      return await GetStationsInformation()
+        .then((response) => {
+          let stationsList: IStationInformation[] = [];
+          const { data } = response.data
+          const { stations } = data
+          const unMappedStations = _.filter(stations, (item) => (item.region_id === regionInformation.id));
+          unMappedStations.forEach((station) => {
+            stationsList.push(StationInformationResponseMapper(station));
+          });
+
+          if (stationsList.length > 0) return stationsList;
+        })
+    }
+  }
+}


### PR DESCRIPTION
In the root query (server/src/schema/index.ts), `bikeShareStationsFull` is no longer intended to be used for client side. This was the first experimental graphql query. However, because the endpoint provided a very wholesome and complete data set, I did not have the opportunity to compose a query that required to resolve other types. Hence, I constructed `bikeShareStations` and `regions` root query to better understand graphql type definition, and resolver's relationship.